### PR TITLE
Make GitHub detect *.4 as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.4 linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you like GitHub to detect your `.4` files as Forth.

Thanks!